### PR TITLE
Player attacks in Feature/basic player controls

### DIFF
--- a/Attacks/Attack.js
+++ b/Attacks/Attack.js
@@ -1,0 +1,12 @@
+class Attack {
+    constructor(isFriendly) {
+        this.isFriendly = isFriendly;
+    }
+
+    display() {}         // Called to draw the attack on the canvas
+    update() {}          // Called to move and change the values of the attack
+    hits(entity) {}      // Returns whether or not the attack hit a given entity
+    interact(entity) {}  // Implements the logic of what happens when the attack hits a given entity
+    destroy() {}         // Called when the attack has been terminated
+    isFinished() {}      // Returns true if the attack is meant to be removed from the game
+}

--- a/Attacks/Bullet.js
+++ b/Attacks/Bullet.js
@@ -1,9 +1,10 @@
 class Bullet extends Attack {
-    constructor(x, y, launchAngle, isFriendly) {
+    constructor(x, y, launchAngle, speed, isFriendly) {
         super(isFriendly);
 
+        this.speed = speed;
         this.position = createVector(x,y);
-        this.velocity = p5.Vector.fromAngle(launchAngle);
+        this.velocity = p5.Vector.fromAngle(launchAngle).mult(this.speed);
     }
 
     update() {

--- a/Attacks/Bullet.js
+++ b/Attacks/Bullet.js
@@ -1,0 +1,29 @@
+class Bullet extends Attack {
+    constructor(x, y, launchAngle, isFriendly) {
+        super(isFriendly);
+
+        this.position = createVector(x,y);
+        this.velocity = p5.Vector.fromAngle(launchAngle);
+    }
+
+    update() {
+        this.position.add(this.velocity);
+    }
+
+    isFinished() {
+        // Once the bullet leaves the canvas bounds, it's ready to be removed
+        return this.position.x < 0 || this.position.x > width ||
+               this.position.y < 0 || this.position.y > height;
+    }
+
+    display() {
+        // Change the color based on whether it's an enemy bullet or player bullet
+        if(this.isFriendly) stroke(0,40,150);
+        else stroke(0,150,40);
+        strokeWeight(8);
+        point(this.position.x, this.position.y);
+
+        strokeWeight(2);
+        line(this.position.x, this.position.y, this.position.x - this.velocity.x, this.position.y - this.velocity.y);
+    }
+}

--- a/Attacks/ChargedBullet.js
+++ b/Attacks/ChargedBullet.js
@@ -1,0 +1,23 @@
+class ChargedBullet extends Bullet {
+    constructor(x, y, strength) {
+        super(x, y, -HALF_PI, 6, true);
+
+        this.damage = 5;
+        this.hitsLeft = strength;
+    }
+
+    display() {
+        fill(0,0,200,50);
+        stroke(0,0,200,150);
+        strokeWeight(5+this.hitsLeft)
+        circle(this.position.x,this.position.y, 30+this.hitsLeft*5);
+    }
+
+    update() {
+        this.position.y -= this.speed;
+    }
+
+    isFinished() {
+        return super.isFinished() || this.hitsLeft == 0;
+    }
+}

--- a/Attacks/FreezeWave.js
+++ b/Attacks/FreezeWave.js
@@ -1,0 +1,25 @@
+class FreezeWave extends Attack {
+    constructor(x, y) {
+        super(true);
+
+        this.originPoint = createVector(x, y);
+        this.radius = 0;
+        this.growSpeed = 10;
+    }
+
+    display() {
+        // Draw an arc facing upwards originated at the origin point with the given radius
+        noFill();
+        stroke(0,200,200,150);
+        strokeWeight(10);
+        arc(this.originPoint.x, this.originPoint.y, this.radius*2, this.radius*2, PI, TWO_PI);
+    }
+
+    update() {
+        this.radius += this.growSpeed;
+    }
+
+    isFinished() {
+        return this.radius > height;
+    }
+}

--- a/Attacks/Laser.js
+++ b/Attacks/Laser.js
@@ -1,0 +1,23 @@
+class Laser extends Attack {
+    constructor(x, y) {
+        super(true);
+
+        this.position = createVector(x, y);
+        this.lifetime = 200; //In milliseconds
+        this.laserWidth = 10;
+        this.startTime = millis();
+        this.damage = 5;
+    }
+
+    display() {
+        for(let i=0; i<4; i++) {
+            stroke(0,0,150+i*20, this.lifetime - (millis()-this.startTime));
+            strokeWeight(this.laserWidth*2-i*2);
+            line(this.position.x, this.position.y, this.position.x, 0);
+        }
+    }
+
+    isFinished() {
+        return millis() - this.startTime > this.lifetime;
+    }
+}

--- a/Attacks/PlayerBullet.js
+++ b/Attacks/PlayerBullet.js
@@ -1,8 +1,0 @@
-class PlayerBullet extends Bullet {
-    constructor(x, y, launchAngle) {
-        super(x, y, launchAngle, true);
-
-        this.speed = 10;
-        this.damage = 1;
-    }
-}

--- a/Attacks/PlayerBullet.js
+++ b/Attacks/PlayerBullet.js
@@ -1,0 +1,8 @@
+class PlayerBullet extends Bullet {
+    constructor(x, y, launchAngle) {
+        super(x, y, launchAngle, true);
+
+        this.speed = 10;
+        this.damage = 1;
+    }
+}

--- a/Attacks/SimpleBullet.js
+++ b/Attacks/SimpleBullet.js
@@ -1,0 +1,7 @@
+class SimpleBullet extends Bullet {
+    constructor(x, y, launchAngle) {
+        super(x, y, launchAngle, 8, true);
+
+        this.damage = 1;
+    }
+}

--- a/Entities/Player.js
+++ b/Entities/Player.js
@@ -3,14 +3,14 @@ class Player {
         this.baseHealth = 100;
         this.health = this.baseHealth;
 
-        this.position = new p5.Vector(width/2, height-height/5);
-        this.velocity = new p5.Vector();
-        this.targetVelocity = new p5.Vector();
+        this.position = createVector(width/2, height-height/5);
+        this.velocity = createVector();
+        this.targetVelocity = createVector();
         this.maxSpeed = 4;  // In pixels per frame
         
         this.hitbox  = {'type': 'rect', 'w': 10, 'h': 20};
 
-        this.dashDirection = new p5.Vector();
+        this.dashDirection = createVector();
         this.dashDuration = 150;        // In milliseconds
         this.dashStartTime;             // In milliseconds
 
@@ -115,6 +115,22 @@ class Player {
                 break;
             case RIGHT_ARROW:
                 this.setTargetVelocity('x', 1);
+                break;
+        }
+
+        switch(key) {
+            case ' ':
+                // If the space bar is double clicked, perform the special ability
+                if (isDoubleClick()) {
+                    // Special ability goes here
+                }
+                // If the space bar is simply clicked once, shoot a bullet
+                else {
+                    let x = this.position.x;
+                    let y = this.position.y;
+                    let angle = -HALF_PI;
+                    attacks.push(new PlayerBullet(x, y, angle));
+                }
                 break;
         }
     }

--- a/Entities/Player.js
+++ b/Entities/Player.js
@@ -25,6 +25,9 @@ class Player {
             [20, 0, -20]
         ]
         this.rotation = 0;
+
+        this.hasUsedSpecialAbility = false;
+        this.specialAbilityClass = FreezeWave;
     }
 
     display() {
@@ -149,7 +152,10 @@ class Player {
             case ' ':
                 // If the space bar is double clicked, perform the special ability
                 if (isDoubleClick()) {
-                    // Special ability goes here
+                    if(!this.hasUsedSpecialAbility) {
+                        attacks.push(new this.specialAbilityClass(this.position.x, this.position.y));
+                        this.hasUsedSpecialAbility = true;
+                    }
                 }
                 // If the space bar is simply clicked once, shoot a bullet
                 else {

--- a/Entities/Player.js
+++ b/Entities/Player.js
@@ -13,8 +13,6 @@ class Player {
         this.dashDirection = new p5.Vector();
         this.dashDuration = 150;        // In milliseconds
         this.dashStartTime;             // In milliseconds
-        this.previousKey;
-        this.previousKeyTimePressed;    // In milliseconds
 
         // Angles to rotate the ship according to the velocity direction
         this.rotationMatrix = [
@@ -79,8 +77,8 @@ class Player {
 
     // Function to utilize the arrow keys to activate dashes and set the target velocity
     setTargetVelocity(direction, amount) {
-        // If the player has pressed the same key as last time and pressed it quickly (less than 300ms), they have activated a dash
-        if (keyCode == this.previousKey && millis() - this.previousKeyTimePressed < 300) {
+        // If the player double clicked one of the arrow keys, they have activated a dash
+        if (isDoubleClick()) {
             // Set the x or y direction of the dash
             if (direction == 'x') this.dashDirection.x = amount;
             else this.dashDirection.y = amount;
@@ -101,10 +99,6 @@ class Player {
         }
         // Make sure to scale the velocity to match the max speed
         this.targetVelocity.setMag(this.maxSpeed);
-
-        // Record this key and the time it was pressed to test for dashes in the future
-        this.previousKeyTimePressed = millis();
-        this.previousKey = keyCode;
     }
 
     keyPressed() {

--- a/Scene Management/AchievementScene.js
+++ b/Scene Management/AchievementScene.js
@@ -6,6 +6,7 @@ class AchievementScene extends Scene {
     draw() {
         // Simply draws the title as the "Achievements"
         fill(0);
+        noStroke();
         textSize(30);
         textAlign(CENTER, CENTER);
         text('Achievements', width/2, height/6);

--- a/Scene Management/LevelScene.js
+++ b/Scene Management/LevelScene.js
@@ -1,3 +1,5 @@
+let attacks = [];
+
 class LevelScene extends Scene {
     constructor() {
         super();
@@ -8,12 +10,23 @@ class LevelScene extends Scene {
     draw() {
         // Draw the title as "Level"
         fill(0);
+        noStroke();
         textSize(30);
         textAlign(CENTER, CENTER);
         text('Level', width/2, height/6);
 
         this.player.update();
         this.player.display();
+
+        for (let i=attacks.length-1; i>=0; i--) {
+            let attack = attacks[i];
+
+            attack.update();
+            attack.display();
+
+            // Remove the attack once it's done
+            if (attack.isFinished()) attacks.splice(i,1);
+        }
     }
 
     keyPressed() {

--- a/Scene Management/MainMenuScene.js
+++ b/Scene Management/MainMenuScene.js
@@ -6,6 +6,7 @@ class MainMenuScene extends Scene {
     draw() {
         // Simply draws the title as the "Main Menu"
         fill(0);
+        noStroke();
         textSize(30);
         textAlign(CENTER, CENTER);
         text('Main Menu', width/2, height/6);

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
     <script src="Attacks/SimpleBullet.js"></script>
     <script src="Attacks/ChargedBullet.js"></script>
     <script src="Attacks/Laser.js"></script>
+    <script src="Attacks/FreezeWave.js"></script>
     
     <!-- Other scripts -->
     <script src="playerInput.js"></script>

--- a/index.html
+++ b/index.html
@@ -28,7 +28,9 @@
     <!-- All classes related to attacks -->
     <script src="Attacks/Attack.js"></script>
     <script src="Attacks/Bullet.js"></script>
-    <script src="Attacks/PlayerBullet.js"></script>
+    <script src="Attacks/SimpleBullet.js"></script>
+    <script src="Attacks/ChargedBullet.js"></script>
+    <script src="Attacks/Laser.js"></script>
     
     <!-- Other scripts -->
     <script src="playerInput.js"></script>

--- a/index.html
+++ b/index.html
@@ -24,6 +24,11 @@
     <!-- All classes related to entities -->
     <script src="Entities/Entity.js"></script>
     <script src="Entities/Player.js"></script>
+
+    <!-- All classes related to attacks -->
+    <script src="Attacks/Attack.js"></script>
+    <script src="Attacks/Bullet.js"></script>
+    <script src="Attacks/PlayerBullet.js"></script>
     
     <!-- Other scripts -->
     <script src="playerInput.js"></script>

--- a/playerInput.js
+++ b/playerInput.js
@@ -11,7 +11,7 @@ function mousePressed() {
 
 let previousKey;
 let previousKeyTimePressed;    // In milliseconds
-let doubleClickTime = 300;     // In milliseconds
+let doubleClickTime = 200;     // In milliseconds
 
 function keyPressed() {
     currentScene.keyPressed();

--- a/playerInput.js
+++ b/playerInput.js
@@ -9,10 +9,23 @@ function mousePressed() {
     }
 }
 
+let previousKey;
+let previousKeyTimePressed;    // In milliseconds
+let doubleClickTime = 300;     // In milliseconds
+
 function keyPressed() {
     currentScene.keyPressed();
+
+    // Record this key and the time it was pressed to test for double clicks in the future
+    previousKeyTimePressed = millis();
+    previousKey = keyCode;
 }
 
 function keyReleased() {
     currentScene.keyReleased();
+}
+
+// Returns true if the currently pressed key was also pressed very recently
+function isDoubleClick() {
+    return keyCode == previousKey && millis() - previousKeyTimePressed < doubleClickTime;
 }

--- a/playerInput.js
+++ b/playerInput.js
@@ -12,6 +12,8 @@ function mousePressed() {
 let previousKey;
 let previousKeyTimePressed;    // In milliseconds
 let doubleClickTime = 200;     // In milliseconds
+let keyHoldTime = 500;         // In milliseconds
+let keyPressTimes = [];        // Dictionary to store the time each key was pressed
 
 function keyPressed() {
     currentScene.keyPressed();
@@ -19,13 +21,34 @@ function keyPressed() {
     // Record this key and the time it was pressed to test for double clicks in the future
     previousKeyTimePressed = millis();
     previousKey = keyCode;
+    keyPressTimes.push([previousKey, previousKeyTimePressed]);
 }
 
 function keyReleased() {
     currentScene.keyReleased();
+
+    // Remove the key from the list of pressed keys
+    for (let i=0; i<keyPressTimes.length; i++) {
+        if (keyPressTimes[i][0] == keyCode) {
+            keyPressTimes.splice(i,1);
+            break;
+        }
+    }
 }
 
 // Returns true if the currently pressed key was also pressed very recently
 function isDoubleClick() {
     return keyCode == previousKey && millis() - previousKeyTimePressed < doubleClickTime;
+}
+
+// Returns the duration the given key has been held down for in milliseconds
+// (Returns null if the key isn't being held down)
+function getHeldDownDuration(heldKeyCode) {
+    for (let i=0; i<keyPressTimes.length; i++) {
+        let duration = millis() - keyPressTimes[i][1];
+        if (keyPressTimes[i][0] == heldKeyCode && duration > keyHoldTime) {
+            return duration;
+        }
+    }
+    return null;
 }


### PR DESCRIPTION
Added the basics of player attacks and attack types. Implemented the following changes:
- Added generic attack class for both friend and foe attacks
- Added bullets that can be fired with a single-click of the space bar
- Added charged bullets that can be fired after holding down the space bar
- Added laser that can be fired after holding down the space bar for long enough
- Added freeze wave that can be activated by double-clicking the space bar